### PR TITLE
Method for easy localizer cloning, other changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - '1.12'
   - '1.13'
   - '1.14'
+  - '1.15'
 before_install:
   - go mod tidy
 script:

--- a/core/localizer_test.go
+++ b/core/localizer_test.go
@@ -157,6 +157,19 @@ func (l *LocalizerTest) Test_GetLocalizedMessage() {
 	assert.Equal(l.T(), "Test message", message)
 }
 
+func (l *LocalizerTest) Test_Clone() {
+	defer func() {
+		require.Nil(l.T(), recover())
+	}()
+
+	localizer := l.localizer.Clone()
+	localizer.SetLanguage(language.Russian)
+	
+	assert.NotEqual(l.T(), l.localizer.LanguageTag, localizer.LanguageTag)
+	assert.Equal(l.T(), "Test message", l.localizer.GetLocalizedMessage("message"))
+	assert.Equal(l.T(), "Тестовое сообщение", localizer.GetLocalizedMessage("message"))
+}
+
 func (l *LocalizerTest) Test_GetLocalizedTemplateMessage() {
 	defer func() {
 		require.Nil(l.T(), recover())

--- a/core/sentry_test.go
+++ b/core/sentry_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -61,6 +62,7 @@ func (r ravenPacket) getRequest() (*raven.Http, bool) {
 }
 
 type ravenClientMock struct {
+	raven.Client
 	captured []ravenPacket
 	mu       sync.RWMutex
 	wg       sync.WaitGroup
@@ -92,7 +94,7 @@ func (r *ravenClientMock) CaptureMessageAndWait(message string, tags map[string]
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	defer r.wg.Done()
-	eventID := string(rand.Uint64())
+	eventID := strconv.FormatUint(rand.Uint64(), 10)
 	r.captured = append(r.captured, ravenPacket{
 		EventID:    eventID,
 		Message:    message,

--- a/core/stacktrace/raven_client_interface.go
+++ b/core/stacktrace/raven_client_interface.go
@@ -4,7 +4,28 @@ import "github.com/getsentry/raven-go"
 
 // RavenClientInterface includes all necessary calls from *raven.Client. Therefore, it can be mocked or replaced.
 type RavenClientInterface interface {
+	SetIgnoreErrors(errs []string) error
+	SetDSN(dsn string) error
+	SetRelease(release string)
+	SetEnvironment(environment string)
+	SetDefaultLoggerName(name string)
+	SetSampleRate(rate float32) error
+	Capture(packet *raven.Packet, captureTags map[string]string) (eventID string, ch chan error)
+	CaptureMessage(message string, tags map[string]string, interfaces ...raven.Interface) string
 	CaptureMessageAndWait(message string, tags map[string]string, interfaces ...raven.Interface) string
+	CaptureError(err error, tags map[string]string, interfaces ...raven.Interface) string
 	CaptureErrorAndWait(err error, tags map[string]string, interfaces ...raven.Interface) string
+	CapturePanic(f func(), tags map[string]string, interfaces ...raven.Interface) (err interface{}, errorID string)
+	CapturePanicAndWait(f func(), tags map[string]string, interfaces ...raven.Interface) (err interface{}, errorID string)
+	Close()
+	Wait()
+	URL() string
+	ProjectID() string
+	Release() string
 	IncludePaths() []string
+	SetIncludePaths(p []string)
+	SetUserContext(u *raven.User)
+	SetHttpContext(h *raven.Http)
+	SetTagsContext(t map[string]string)
+	ClearContext()
 }


### PR DESCRIPTION
* `Clone()` method in `Localizer` component allows to clone it just like `LocalizationMiddleware` does.
* `RavenClientInterface` contains all `*raven.Client` method, which allows external use without type casting.
* Tests and godoc fix for Go 1.15.