### PR TITLE
fix: several problems with queue & worker impl

### DIFF
--- a/core/queue/memory.go
+++ b/core/queue/memory.go
@@ -56,12 +56,12 @@ func NewMemory[T any](id int) (Queue[T], context.CancelFunc) {
 
 // Enqueue adds an item to the end of the queue.
 func (q *Memory[T]) Enqueue(item T) error {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+
 	if err := q.ctx.Err(); err != nil {
 		return err
 	}
-
-	q.mutex.Lock()
-	defer q.mutex.Unlock()
 
 	q.items.PushBack(item)
 	atomic.AddInt64(&q.size, 1)
@@ -72,6 +72,26 @@ func (q *Memory[T]) Enqueue(item T) error {
 
 // Dequeue an item from the queue start.
 func (q *Memory[T]) Dequeue() (T, error) {
+	return q.DequeueContext(context.Background())
+}
+
+// DequeueContext removes an item from the queue start or returns when ctx or queue context is canceled.
+func (q *Memory[T]) DequeueContext(ctx context.Context) (T, error) {
+	if ctx.Done() != nil {
+		done := make(chan struct{})
+		defer close(done)
+
+		go func() {
+			select {
+			case <-ctx.Done():
+				q.mutex.Lock()
+				q.cond.Broadcast()
+				q.mutex.Unlock()
+			case <-done:
+			}
+		}()
+	}
+
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
@@ -80,7 +100,15 @@ func (q *Memory[T]) Dequeue() (T, error) {
 			var zero T
 			return zero, err
 		}
+		if err := ctx.Err(); err != nil {
+			var zero T
+			return zero, err
+		}
 		q.cond.Wait()
+	}
+	if err := ctx.Err(); err != nil {
+		var zero T
+		return zero, err
 	}
 
 	item := q.items.Remove(q.items.Front()).(T)

--- a/core/queue/store.go
+++ b/core/queue/store.go
@@ -118,7 +118,8 @@ func (s *Store[T]) Remove(id int) {
 }
 
 // performAutoScale will call ScaleFunc for the queue every checkInterval until the queue context is canceled.
-func (s *Store[T]) performAutoScale(ctx context.Context, id int, queue Info, scaleFunc ScaleFunc, checkInterval time.Duration) {
+func (s *Store[T]) performAutoScale(
+	ctx context.Context, id int, queue Info, scaleFunc ScaleFunc, checkInterval time.Duration) {
 	defer func() {
 		if r := recover(); r != nil && ctx.Err() == nil {
 			go s.performAutoScale(ctx, id, queue, scaleFunc, checkInterval)

--- a/core/queue/store.go
+++ b/core/queue/store.go
@@ -142,6 +142,9 @@ func (s *Store[T]) addWorker(id int) {
 	if s.numWorkers == s.maxNumWorkers {
 		return
 	}
+	if s.workerConstructor == nil {
+		return
+	}
 	q, exists := s.m.Load(id)
 	if !exists {
 		return
@@ -179,17 +182,21 @@ func (s *Store[T]) stopWorker(id int) {
 		return
 	}
 
-	defer s.stopsLock.Unlock()
 	s.stopsLock.Lock()
 	stops, ok := s.stops[id]
 	if !ok || stops == nil {
+		s.stopsLock.Unlock()
 		return
 	}
 	if len(stops.workers) <= 1 {
+		s.stopsLock.Unlock()
 		return
 	}
-	stops.workers[len(stops.workers)-1]()
+	stop := stops.workers[len(stops.workers)-1]
 	s.stops[id].workers = stops.workers[:len(stops.workers)-1]
+	s.stopsLock.Unlock()
+
+	stop()
 }
 
 // scalingInfo returns how many additional workers can be spawned and how many of them are active.
@@ -210,18 +217,22 @@ func (s *Store[T]) scalingInfo(id int) (slotsLeft, slotsActive int) {
 
 // invokeStoppers stops the queue and all workers for the queue with specified id.
 func (s *Store[T]) invokeStoppers(id int) {
-	defer s.stopsLock.Unlock()
 	s.stopsLock.Lock()
-	if stops, ok := s.stops[id]; ok {
-		if stops == nil {
-			return
-		}
-		if stops.queue != nil {
-			stops.queue()
-		}
-		for _, fn := range stops.workers {
-			fn()
-		}
+	stops, ok := s.stops[id]
+	if !ok || stops == nil {
+		s.stopsLock.Unlock()
+		return
+	}
+	queueStop := stops.queue
+	workerStops := append([]context.CancelFunc(nil), stops.workers...)
+	delete(s.stops, id)
+	s.stopsLock.Unlock()
+
+	if queueStop != nil {
+		queueStop()
+	}
+	for _, fn := range workerStops {
+		fn()
 	}
 }
 

--- a/core/queue/store.go
+++ b/core/queue/store.go
@@ -23,8 +23,12 @@ type ScaleFunc func(q Info, addWorker, deleteWorker func(), availableScaling fun
 // Store stores queues and manages their workers.
 type Store[T any] struct {
 	m                 sync.Map
+	getLock           sync.Mutex
 	stopsLock         sync.Mutex
 	stops             map[int]*stopFuncList
+	scaleLock         sync.RWMutex
+	scaleFunc         ScaleFunc
+	scaleInterval     time.Duration
 	constructor       Constructor[T]
 	numWorkers        int
 	maxNumWorkers     int
@@ -66,46 +70,72 @@ func (s *Store[T]) WithMaxNumWorkers(n int) *Store[T] {
 
 // WithScaleFunc will start scaling func each checkInterval.
 func (s *Store[T]) WithScaleFunc(fn ScaleFunc, checkInterval time.Duration) *Store[T] {
-	go s.performAutoScale(fn, checkInterval)
+	s.scaleLock.Lock()
+	s.scaleFunc = fn
+	s.scaleInterval = checkInterval
+	s.scaleLock.Unlock()
+
+	s.m.Range(func(key, value any) bool {
+		id, idOk := key.(int)
+		queue, queueOk := value.(Info)
+		if idOk && queueOk {
+			go s.performAutoScale(queue.Context(), id, queue, fn, checkInterval)
+		}
+		return true
+	})
+
 	return s
 }
 
 // Get queue from the store.
 func (s *Store[T]) Get(id int) Queue[T] {
-	val, exists := s.m.Load(id)
-	if !exists {
-		q, stop := s.constructor(id)
-		s.m.Store(id, q)
-		s.spawnWorkers(id, stop, q)
-		return q
+	if val, exists := s.m.Load(id); exists {
+		return val.(Queue[T])
 	}
-	return val.(Queue[T])
+
+	s.getLock.Lock()
+	defer s.getLock.Unlock()
+
+	if val, exists := s.m.Load(id); exists {
+		return val.(Queue[T])
+	}
+
+	q, stop := s.constructor(id)
+	s.m.Store(id, q)
+	s.spawnWorkers(id, stop, q)
+	s.spawnAutoScale(id, q)
+
+	return q
 }
 
 // Remove queue from the store.
 func (s *Store[T]) Remove(id int) {
+	s.getLock.Lock()
+	defer s.getLock.Unlock()
+
 	s.invokeStoppers(id)
 	s.m.Delete(id)
 }
 
-// performAutoScale will call ScaleFunc on each queue every checkInterval.
-func (s *Store[T]) performAutoScale(scaleFunc ScaleFunc, checkInterval time.Duration) {
+// performAutoScale will call ScaleFunc for the queue every checkInterval until the queue context is canceled.
+func (s *Store[T]) performAutoScale(ctx context.Context, id int, queue Info, scaleFunc ScaleFunc, checkInterval time.Duration) {
 	defer func() {
-		if r := recover(); r != nil {
-			go s.performAutoScale(scaleFunc, checkInterval)
+		if r := recover(); r != nil && ctx.Err() == nil {
+			go s.performAutoScale(ctx, id, queue, scaleFunc, checkInterval)
 			return
 		}
 	}()
+
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
 	for {
-		time.Sleep(checkInterval)
-		s.m.Range(func(key, value any) bool {
-			id, ok := key.(int)
-			if !ok {
-				return true
-			}
-			queue, ok := value.(Info)
-			if !ok {
-				return true
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if ctx.Err() != nil {
+				return
 			}
 			scaleFunc(queue, func() {
 				s.addWorker(id)
@@ -114,9 +144,21 @@ func (s *Store[T]) performAutoScale(scaleFunc ScaleFunc, checkInterval time.Dura
 			}, func() (int, int) {
 				return s.scalingInfo(id)
 			})
-			return true
-		})
+		}
 	}
+}
+
+func (s *Store[T]) spawnAutoScale(id int, q Queue[T]) {
+	s.scaleLock.RLock()
+	scaleFunc := s.scaleFunc
+	checkInterval := s.scaleInterval
+	s.scaleLock.RUnlock()
+
+	if scaleFunc == nil || checkInterval <= 0 {
+		return
+	}
+
+	go s.performAutoScale(q.Context(), id, q, scaleFunc, checkInterval)
 }
 
 // addStoppers adds stop functions to the storage.

--- a/core/queue/store_test.go
+++ b/core/queue/store_test.go
@@ -25,6 +25,60 @@ func TestStore_GetReturnsSameQueue(t *testing.T) {
 	assert.Equal(t, q1, q2)
 }
 
+func TestStore_GetSameQueueConcurrentlyCreatesOnce(t *testing.T) {
+	constructed := int32(0)
+	startedWorkers := int32(0)
+
+	constructor := func(id int) (Queue[int], context.CancelFunc) {
+		atomic.AddInt32(&constructed, 1)
+		time.Sleep(10 * time.Millisecond)
+		return NewMemory[int](id)
+	}
+	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
+		ctx, cancel := context.WithCancel(context.Background())
+		atomic.AddInt32(&startedWorkers, 1)
+		return NewWorker(ctx, func(_ int, _ Queue[int]) {}, RecoverFuncDummy[int]), cancel
+	}
+
+	store := NewStore(constructor).
+		WithWorkerConstructor(workerConstructor).
+		WithNumWorkers(1)
+
+	const goroutines = 25
+	start := make(chan struct{})
+	queues := make(chan Queue[int], goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			queues <- store.Get(1)
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(queues)
+
+	var first Queue[int]
+	for q := range queues {
+		if first == nil {
+			first = q
+			continue
+		}
+		if first != q {
+			t.Fatal("expected concurrent Get calls to return the same queue")
+		}
+	}
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&constructed))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&startedWorkers))
+
+	store.Remove(1)
+}
+
 func TestStore_GetDifferentQueues(t *testing.T) {
 	store := NewStore(NewMemory[int])
 	q1 := store.Get(1)
@@ -216,6 +270,36 @@ func TestStore_WithScaleFunc(t *testing.T) {
 	assert.Positive(t, atomic.LoadInt32(&addWorkerCalled))
 
 	store.Remove(1)
+}
+
+func TestStore_AutoScaleStopsWhenQueueStops(t *testing.T) {
+	scaleCalled := make(chan struct{}, 2)
+	unblockScale := make(chan struct{})
+
+	scaleFunc := func(_ Info, _, _ func(), _ func() (int, int)) {
+		scaleCalled <- struct{}{}
+		<-unblockScale
+	}
+
+	store := NewStore(NewMemory[int]).
+		WithScaleFunc(scaleFunc, 10*time.Millisecond)
+
+	store.Get(1)
+
+	select {
+	case <-scaleCalled:
+	case <-time.After(time.Second):
+		t.Fatal("scale function was not called")
+	}
+
+	store.Remove(1)
+	close(unblockScale)
+
+	select {
+	case <-scaleCalled:
+		t.Fatal("scale function was called after queue stop")
+	case <-time.After(50 * time.Millisecond):
+	}
 }
 
 func TestStore_AddWorkerRespectMaxLimit(t *testing.T) {

--- a/core/queue/store_test.go
+++ b/core/queue/store_test.go
@@ -64,9 +64,10 @@ func TestStore_WithNumWorkers(t *testing.T) {
 	workerCount := int32(0)
 
 	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
-		_, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		atomic.AddInt32(&workerCount, 1)
 		worker := NewWorker(
+			ctx,
 			func(_ int, _ Queue[int]) {
 				atomic.AddInt32(&processed, 1)
 			},
@@ -103,8 +104,9 @@ func TestStore_WithWorkerConstructor(t *testing.T) {
 	var mu sync.Mutex
 
 	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
-		_, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		worker := NewWorker(
+			ctx,
 			func(item int, _ Queue[int]) {
 				mu.Lock()
 				processed = append(processed, item)
@@ -138,8 +140,9 @@ func TestStore_WithWorkerConstructor(t *testing.T) {
 
 func TestStore_WithMaxNumWorkers(t *testing.T) {
 	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
-		_, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		worker := NewWorker(
+			ctx,
 			func(_ int, _ Queue[int]) {
 				time.Sleep(10 * time.Millisecond)
 			},
@@ -167,8 +170,9 @@ func TestStore_WithMaxNumWorkers(t *testing.T) {
 
 func TestStore_WithScaleFunc(t *testing.T) {
 	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
-		_, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		worker := NewWorker(
+			ctx,
 			func(_ int, _ Queue[int]) {
 				time.Sleep(50 * time.Millisecond)
 			},
@@ -216,8 +220,9 @@ func TestStore_WithScaleFunc(t *testing.T) {
 
 func TestStore_AddWorkerRespectMaxLimit(t *testing.T) {
 	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
-		_, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		worker := NewWorker(
+			ctx,
 			func(_ int, _ Queue[int]) {},
 			RecoverFuncDummy[int],
 		)
@@ -252,8 +257,9 @@ func TestStore_AddWorkerRespectMaxLimit(t *testing.T) {
 
 func TestStore_StopWorkerRespectMinLimit(t *testing.T) {
 	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
-		_, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		worker := NewWorker(
+			ctx,
 			func(_ int, _ Queue[int]) {},
 			RecoverFuncDummy[int],
 		)
@@ -284,10 +290,64 @@ func TestStore_StopWorkerRespectMinLimit(t *testing.T) {
 	store.Remove(1)
 }
 
+func TestStore_StopWorkerCancelsIdleWorker(t *testing.T) {
+	started := int32(0)
+	stopped := make(chan int32, 2)
+	processed := make(chan int, 1)
+
+	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
+		ctx, cancel := context.WithCancel(context.Background())
+		workerID := atomic.AddInt32(&started, 1)
+		worker := NewWorker(
+			ctx,
+			func(item int, _ Queue[int]) {
+				processed <- item
+			},
+			RecoverFuncDummy[int],
+			func() { stopped <- workerID },
+		)
+		return worker, cancel
+	}
+
+	store := NewStore(NewMemory[int]).
+		WithWorkerConstructor(workerConstructor).
+		WithNumWorkers(1).
+		WithMaxNumWorkers(3)
+
+	q := store.Get(1)
+	time.Sleep(50 * time.Millisecond)
+
+	store.addWorker(1)
+	require.Eventually(t, func() bool {
+		_, active := store.scalingInfo(1)
+		return active == 2
+	}, time.Second, 10*time.Millisecond)
+
+	store.stopWorker(1)
+
+	select {
+	case workerID := <-stopped:
+		assert.Equal(t, int32(2), workerID)
+	case <-time.After(time.Second):
+		t.Fatal("downscaled worker was not canceled")
+	}
+
+	require.NoError(t, q.Enqueue(10))
+	select {
+	case item := <-processed:
+		assert.Equal(t, 10, item)
+	case <-time.After(time.Second):
+		t.Fatal("remaining worker did not process after downscale")
+	}
+
+	store.Remove(1)
+}
+
 func TestStore_ConcurrentAccess(t *testing.T) {
 	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
-		_, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		worker := NewWorker(
+			ctx,
 			func(_ int, _ Queue[int]) {},
 			RecoverFuncDummy[int],
 		)
@@ -323,8 +383,9 @@ func TestStore_ConcurrentAccess(t *testing.T) {
 
 func TestStore_ScaleFuncPanicRecovery(t *testing.T) {
 	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
-		_, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		worker := NewWorker(
+			ctx,
 			func(_ int, _ Queue[int]) {},
 			RecoverFuncDummy[int],
 		)
@@ -362,12 +423,98 @@ func TestStore_ScaleFuncPanicRecovery(t *testing.T) {
 	store.Remove(1)
 }
 
+func TestStore_WithScaleFuncCancelsUpscaledWorker(t *testing.T) {
+	started := int32(0)
+	stopped := make(chan int32, 2)
+	scaledDown := make(chan struct{}, 1)
+
+	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
+		ctx, cancel := context.WithCancel(context.Background())
+		workerID := atomic.AddInt32(&started, 1)
+		worker := NewWorker(
+			ctx,
+			func(_ int, _ Queue[int]) {},
+			RecoverFuncDummy[int],
+			func() { stopped <- workerID },
+		)
+		return worker, cancel
+	}
+
+	scalePhase := int32(0)
+	scaleFunc := func(_ Info, addWorker, deleteWorker func(), availableScaling func() (int, int)) {
+		switch atomic.LoadInt32(&scalePhase) {
+		case 0:
+			slotsLeft, slotsActive := availableScaling()
+			if slotsActive == 1 && slotsLeft > 0 && atomic.CompareAndSwapInt32(&scalePhase, 0, 1) {
+				addWorker()
+			}
+		case 1:
+			_, slotsActive := availableScaling()
+			if slotsActive == 2 && atomic.CompareAndSwapInt32(&scalePhase, 1, 2) {
+				deleteWorker()
+				scaledDown <- struct{}{}
+			}
+		}
+	}
+
+	store := NewStore(NewMemory[int]).
+		WithWorkerConstructor(workerConstructor).
+		WithNumWorkers(1).
+		WithMaxNumWorkers(2).
+		WithScaleFunc(scaleFunc, 10*time.Millisecond)
+
+	store.Get(1)
+
+	select {
+	case <-scaledDown:
+	case <-time.After(time.Second):
+		t.Fatal("scale function did not downscale")
+	}
+
+	select {
+	case workerID := <-stopped:
+		assert.Equal(t, int32(2), workerID)
+	case <-time.After(time.Second):
+		t.Fatal("upscaled worker was not canceled")
+	}
+
+	_, active := store.scalingInfo(1)
+	assert.Equal(t, 1, active)
+
+	store.Remove(1)
+}
+
+func TestStore_RemoveClearsStaleWorkerStops(t *testing.T) {
+	workerConstructor := func(_ int) (Worker[int], context.CancelFunc) {
+		ctx, cancel := context.WithCancel(context.Background())
+		return NewWorker(ctx, func(_ int, _ Queue[int]) {}, RecoverFuncDummy[int]), cancel
+	}
+
+	store := NewStore(NewMemory[int]).
+		WithWorkerConstructor(workerConstructor).
+		WithNumWorkers(2).
+		WithMaxNumWorkers(3)
+
+	first := store.Get(1)
+	store.Remove(1)
+	second := store.Get(1)
+
+	if first == second {
+		t.Fatal("expected queue to be recreated after removal")
+	}
+	_, active := store.scalingInfo(1)
+	assert.Equal(t, 2, active)
+
+	store.Remove(1)
+}
+
 func TestStore_MultipleQueuesIndependentWorkers(t *testing.T) {
 	processed := sync.Map{}
 
 	workerConstructor := func(_ int) (Worker[func() (int, func())], context.CancelFunc) {
-		_, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		worker := NewWorker(
+			ctx,
 			func(item func() (int, func()), q Queue[func() (int, func())]) {
 				num, finish := item()
 				key := q.ID()

--- a/core/queue/worker.go
+++ b/core/queue/worker.go
@@ -8,7 +8,10 @@ import (
 type (
 	// Worker represents function which dequeues an item from provided queue and does something with it.
 	// Useful when NewWorker implementation isn't agile enough.
-	Worker[T any] func(Queue[T])
+	Worker[T any]       func(Queue[T])
+	contextQueue[T any] interface {
+		DequeueContext(context.Context) (T, error)
+	}
 	// Processor accepts incoming job and does something with it.
 	Processor[T any] func(T, Queue[T])
 	// RecoverFunc handles output value received from recover() call.
@@ -17,14 +20,30 @@ type (
 
 // NewWorker constructs new worker that will retry the given processor until it succeeds
 // or is interrupted by the context cancellation. `recover()` value in cause of panics is handled by provided recoverFn.
-func NewWorker[T any](processor Processor[T], recoverFn RecoverFunc[T], cancelCallbacks ...func()) Worker[T] {
+func NewWorker[T any](ctx context.Context, processor Processor[T], recoverFn RecoverFunc[T], cancelCallbacks ...func()) Worker[T] {
 	return func(q Queue[T]) {
+		callCancelCallbacks := func() {
+			for _, cb := range cancelCallbacks {
+				cb()
+			}
+		}
+		dequeue := q.Dequeue
+		if contextQueue, ok := q.(contextQueue[T]); ok {
+			dequeue = func() (T, error) {
+				return contextQueue.DequeueContext(ctx)
+			}
+		}
+
 		for {
-			var err error
-			job, err := q.Dequeue()
-			if err != nil && errors.Is(err, context.Canceled) {
-				for _, cb := range cancelCallbacks {
-					cb()
+			if ctx.Err() != nil {
+				callCancelCallbacks()
+				return
+			}
+
+			job, err := dequeue()
+			if err != nil {
+				if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+					callCancelCallbacks()
 				}
 				return
 			}

--- a/core/queue/worker.go
+++ b/core/queue/worker.go
@@ -20,7 +20,8 @@ type (
 
 // NewWorker constructs new worker that will retry the given processor until it succeeds
 // or is interrupted by the context cancellation. `recover()` value in cause of panics is handled by provided recoverFn.
-func NewWorker[T any](ctx context.Context, processor Processor[T], recoverFn RecoverFunc[T], cancelCallbacks ...func()) Worker[T] {
+func NewWorker[T any](
+	ctx context.Context, processor Processor[T], recoverFn RecoverFunc[T], cancelCallbacks ...func()) Worker[T] {
 	return func(q Queue[T]) {
 		callCancelCallbacks := func() {
 			for _, cb := range cancelCallbacks {

--- a/core/queue/worker_test.go
+++ b/core/queue/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewWorker_ProcessesItems(t *testing.T) {
@@ -20,8 +21,9 @@ func TestNewWorker_ProcessesItems(t *testing.T) {
 		mu.Unlock()
 	}
 
-	worker := NewWorker(processor, RecoverFuncDummy[int])
+	worker := NewWorker(context.Background(), processor, RecoverFuncDummy[int])
 	q, cancel := NewMemory[int](1)
+	defer cancel()
 
 	go worker(q)
 
@@ -51,8 +53,9 @@ func TestNewWorker_ProcessesItemsInOrder(t *testing.T) {
 		mu.Unlock()
 	}
 
-	worker := NewWorker(processor, RecoverFuncDummy[int])
+	worker := NewWorker(context.Background(), processor, RecoverFuncDummy[int])
 	q, cancel := NewMemory[int](1)
+	defer cancel()
 
 	go worker(q)
 
@@ -82,11 +85,13 @@ func TestNewWorker_StopsOnContextCancellation(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	worker := NewWorker(processor, RecoverFuncDummy[int], func() {
+	ctx, workerCancel := context.WithCancel(context.Background())
+	worker := NewWorker(ctx, processor, RecoverFuncDummy[int], func() {
 		stopped <- true
 	})
 
 	q, cancel := NewMemory[int](1)
+	defer cancel()
 
 	go worker(q)
 
@@ -95,13 +100,43 @@ func TestNewWorker_StopsOnContextCancellation(t *testing.T) {
 	}
 
 	time.Sleep(50 * time.Millisecond)
-	cancel()
+	workerCancel()
 
 	select {
 	case <-stopped:
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Worker did not stop after context cancellation")
 	}
+}
+
+func TestNewWorker_StopsIdleWorkerOnParentContextCancellation(t *testing.T) {
+	ctx, workerCancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{}, 1)
+
+	worker := NewWorker(
+		ctx,
+		func(_ int, _ Queue[int]) {
+			t.Fatal("processor should not run")
+		},
+		RecoverFuncDummy[int],
+		func() { stopped <- struct{}{} },
+	)
+
+	q, cancel := NewMemory[int](1)
+	defer cancel()
+
+	go worker(q)
+
+	workerCancel()
+
+	select {
+	case <-stopped:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Worker did not stop after parent context cancellation")
+	}
+
+	require.NoError(t, q.Enqueue(1))
+	assert.Equal(t, int64(1), q.Len())
 }
 
 func TestNewWorker_HandlesPanic(t *testing.T) {
@@ -121,7 +156,7 @@ func TestNewWorker_HandlesPanic(t *testing.T) {
 		assert.Equal(t, "test panic", r)
 	}
 
-	worker := NewWorker(processor, recoverFunc)
+	worker := NewWorker(context.Background(), processor, recoverFunc)
 	q, cancel := NewMemory[int](1)
 
 	go worker(q)
@@ -154,7 +189,7 @@ func TestNewWorker_ContinuesAfterPanic(t *testing.T) {
 
 	recoverFunc := func(_ context.Context, _ int, _ any) {}
 
-	worker := NewWorker(processor, recoverFunc)
+	worker := NewWorker(context.Background(), processor, recoverFunc)
 	q, cancel := NewMemory[int](1)
 
 	go worker(q)
@@ -183,6 +218,7 @@ func TestNewWorker_MultipleCancelCallbacks(t *testing.T) {
 	processor := func(_ int, _ Queue[int]) {}
 
 	worker := NewWorker(
+		context.Background(),
 		processor,
 		RecoverFuncDummy[int],
 		func() { atomic.AddInt32(&callback1Called, 1) },
@@ -216,7 +252,7 @@ func TestNewWorker_RecoverFuncHasContext(t *testing.T) {
 		mu.Unlock()
 	}
 
-	worker := NewWorker(processor, recoverFunc)
+	worker := NewWorker(context.Background(), processor, recoverFunc)
 	q, cancel := NewMemory[int](1)
 
 	go worker(q)
@@ -243,7 +279,7 @@ func TestNewWorker_ConcurrentProcessing(t *testing.T) {
 	q, cancel := NewMemory[int](1)
 
 	for i := 0; i < 5; i++ {
-		worker := NewWorker(processor, RecoverFuncDummy[int])
+		worker := NewWorker(context.Background(), processor, RecoverFuncDummy[int])
 		go worker(q)
 	}
 
@@ -260,7 +296,7 @@ func TestNewWorker_ConcurrentProcessing(t *testing.T) {
 func TestNewWorker_HandlesContextCanceledError(t *testing.T) {
 	processor := func(_ int, _ Queue[int]) {}
 
-	worker := NewWorker(processor, RecoverFuncDummy[int])
+	worker := NewWorker(context.Background(), processor, RecoverFuncDummy[int])
 	q, cancel := NewMemory[int](1)
 
 	done := make(chan bool, 1)
@@ -344,7 +380,7 @@ func TestNewWorker_ProcessorAccessesQueue(t *testing.T) {
 		}
 	}
 
-	worker := NewWorker(processor, RecoverFuncDummy[int])
+	worker := NewWorker(context.Background(), processor, RecoverFuncDummy[int])
 	q, cancel := NewMemory[int](42)
 
 	go worker(q)
@@ -369,7 +405,7 @@ func TestNewWorker_ZeroValueItems(t *testing.T) {
 		mu.Unlock()
 	}
 
-	worker := NewWorker(processor, RecoverFuncDummy[int])
+	worker := NewWorker(context.Background(), processor, RecoverFuncDummy[int])
 	q, cancel := NewMemory[int](1)
 
 	go worker(q)
@@ -397,7 +433,7 @@ func TestNewWorker_EmptyQueue(t *testing.T) {
 		atomic.AddInt32(&processed, 1)
 	}
 
-	worker := NewWorker(processor, RecoverFuncDummy[int])
+	worker := NewWorker(context.Background(), processor, RecoverFuncDummy[int])
 	q, cancel := NewMemory[int](1)
 
 	go worker(q)


### PR DESCRIPTION
This fixes:
- Problems with cancellation in `NewWorker`
- Lack of `context.Context` support in the queue
- Queue downscale which didn't account for stale stoppers & could race
- `performAutoScale` is now per-queue and exits when that queue’s context is canceled.
- `Store.Get` is now atomic (could race before).